### PR TITLE
no play link if Resi is available

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -217,14 +217,16 @@ class dataSource extends ContentItem.dataSource {
 
   createHtmlHeader = (item) => {
     let header = '';
-    if (item.attributeValues.vimeoId?.value) {
-      header = `${header}<a href="https://vimeo.com/${
-        item.attributeValues.vimeoId?.value
-      }">Play Sermon Video</a>`;
-    } else if (item.attributeValues.youtubeId?.value) {
-      header = `${header}<a href="https://www.youtube.com/watch?v=${
-        item.attributeValues.youtubeId?.value
-      }">Play Sermon Video</a>`;
+    if (!item.attributeValues.resiVodurl?.value) {
+      if (item.attributeValues.vimeoId?.value) {
+        header = `${header}<a href="https://vimeo.com/${
+          item.attributeValues.vimeoId?.value
+        }">Play Sermon Video</a>`;
+      } else if (item.attributeValues.youtubeId?.value) {
+        header = `${header}<a href="https://www.youtube.com/watch?v=${
+          item.attributeValues.youtubeId?.value
+        }">Play Sermon Video</a>`;
+      }
     }
 
     if (header !== '') header = `<p>${header}</p>`;


### PR DESCRIPTION
Removes the Play Sermon Video link if a Resi link is on the content item. The Play Sermon Video link will only appear if Resi is not on the content item and YouTube or Vimeo has a value.