### PR TITLE
fix: filtering if items have multiple campuses

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -55,9 +55,9 @@ class dataSource extends ContentItem.dataSource {
     });
     const congregationAttributeValues = await this.request('AttributeValues')
       .filter(
-        `AttributeId eq 8701 and Value eq '${name
+        `AttributeId eq 8701 and substringof('${name
           .toLowerCase()
-          .replace(' ', '-')}'`
+          .replace(' ', '-')}', Value) eq true`
       )
       .cache({ ttl: 60 })
       .get();
@@ -98,9 +98,9 @@ class dataSource extends ContentItem.dataSource {
     if (id === 12) {
       const congregationAttributeValues = await this.request('AttributeValues')
         .filter(
-          `AttributeId eq 17890 and Value eq '${name
+          `AttributeId eq 17890 and substringof('${name
             .toLowerCase()
-            .replace(' ', '-')}'`
+            .replace(' ', '-')}', Value) eq true`
         )
         .cache({ ttl: 60 })
         .get();


### PR DESCRIPTION
Before, if a content item had multiple campuses associated with it, that item would not be shown. This fixes that and searches for the current user's campus in the campuses associated with an item. This also future proofs this filter for all other content items.

Before:
<img src="https://user-images.githubusercontent.com/72768221/135309032-c38999d8-9b36-468a-a457-11774f5982f2.png" width="50%" >

After:

https://user-images.githubusercontent.com/72768221/135309095-b0f2ac6d-2a15-4c08-b66a-aa08cd2a1435.mp4



