### PR TITLE
fix: Daily and Weekly Scripture Feeds

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -305,14 +305,22 @@ TABS:
       isCard: false
       type: PrayerList
       subtitle: Daily Prayer
-    - subtitle: Grow Together
+    - subtitle: Grow Together # This pulls the Daily Scripture for today
       algorithms:
-        - type: CONTENT_FEED
+      - type: CONTENT_FEED
+        arguments:
+          limit: 1
+          channelIds:
+            - 32
+      type: VerticalCardList   
+    - algorithms:
+        - type: DAILY_SCRIPTURE_FEED # This pulls the 5 Daily Scriptures for this week
           arguments:
-            limit: 1
+            limit: 5
             channelIds:
               - 32
-      type: VerticalCardList
+      type: ActionList
+      isCard: false # This doesn't work for some reason?
     - algorithms:
         - type: CONTENT_FEED
           arguments:

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -315,7 +315,7 @@ TABS:
       type: VerticalCardList   
     - subtitle: Weekly Readings
       algorithms:
-        - type: DAILY_SCRIPTURE_FEED # This pulls the 5 Daily Scriptures for this week
+        - type: WEEKLY_SCRIPTURE_FEED # This pulls the 5 Daily Scriptures for this week
           arguments:
             limit: 5
             channelIds:

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -313,7 +313,8 @@ TABS:
           channelIds:
             - 32
       type: VerticalCardList   
-    - algorithms:
+    - subtitle: Weekly Readings
+      algorithms:
         - type: DAILY_SCRIPTURE_FEED # This pulls the 5 Daily Scriptures for this week
           arguments:
             limit: 5

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -307,7 +307,7 @@ TABS:
       subtitle: Daily Prayer
     - subtitle: Grow Together # This pulls the Daily Scripture for today
       algorithms:
-      - type: DAILY_SCRIPTURE_FEED
+      - type: CONTENT_FEED
         arguments:
           limit: 1
           channelIds:

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -307,7 +307,7 @@ TABS:
       subtitle: Daily Prayer
     - subtitle: Grow Together # This pulls the Daily Scripture for today
       algorithms:
-      - type: CONTENT_FEED
+      - type: DAILY_SCRIPTURE_FEED
         arguments:
           limit: 1
           channelIds:

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -105,9 +105,9 @@ class dataSource extends ActionAlgorithm.dataSource {
     const items = (await Promise.all(
       channelIds.map(async (channel) =>
         (await ContentItem.byContentChannelId(channel, category, false))
-          // First, get all the items for this week (even if not live yet)
           .top(limit)
           .skip(skip)
+          .sort([{ field: 'StartDateTime', direction: 'asc' }])
           // Then, sort chronologically ascending
           .get()
       )

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -5,7 +5,6 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     PRIORITY_CONTENT_FEED: this.priorityContentFeedAlgorithm.bind(this),
-    DAILY_SCRIPTURE_FEED: this.dailyScriptureFeedAlgorithm.bind(this),
     WEEKLY_SCRIPTURE_FEED: this.weeklyScriptureFeedAlgorithm.bind(this),
   };
 
@@ -51,34 +50,6 @@ class dataSource extends ActionAlgorithm.dataSource {
           .top(limit)
           .skip(skip)
           .sort([{ field: 'Priority', direction: 'asc' }])
-          .get()
-      )
-    )).flat();
-
-    return items.map((item, i) => ({
-      id: `${item.id}${i}`,
-      title: item.title,
-      subtitle: item.contentChannel?.name,
-      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
-      image: ContentItem.getCoverImage(item),
-      action: 'READ_CONTENT',
-      summary: ContentItem.createSummary(item),
-    }));
-  }
-
-  async dailyScriptureFeedAlgorithm({
-    category = '',
-    channelIds = [],
-    limit = 20,
-    skip = 0,
-  } = {}) {
-    const { ContentItem } = this.context.dataSources;
-
-    const items = (await Promise.all(
-      channelIds.map(async (channel) =>
-        (await ContentItem.byContentChannelId(channel, category))
-          .top(limit)
-          .skip(skip)
           .get()
       )
     )).flat();

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -1,4 +1,5 @@
 import { ActionAlgorithm } from '@apollosproject/data-connector-rock';
+import { isThisWeek } from 'date-fns';
 
 class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
@@ -74,7 +75,7 @@ class dataSource extends ActionAlgorithm.dataSource {
 
     const items = (await Promise.all(
       channelIds.map(async (channel) =>
-        (await ContentItem.byContentChannelId(channel, category))
+        (await ContentItem.byContentChannelId(channel, category, false))
           // First, get all the items for this week (even if not live yet)
           .top(limit)
           .skip(skip)
@@ -83,7 +84,11 @@ class dataSource extends ActionAlgorithm.dataSource {
       )
     )).flat();
 
-    return items.map((item, i) => ({
+    const itemsByDate = items.filter((key) =>
+      isThisWeek(new Date(key.startDateTime))
+    );
+
+    return itemsByDate.map((item, i) => ({
       id: `${item.id}${i}`,
       title: item.title,
       subtitle: item.contentChannel?.name,

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -79,7 +79,6 @@ class dataSource extends ActionAlgorithm.dataSource {
           .top(limit)
           .skip(skip)
           .sort([{ field: 'StartDateTime', direction: 'asc' }])
-          // Then, sort chronologically ascending
           .get()
       )
     )).flat();

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -67,7 +67,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   async dailyScriptureFeedAlgorithm({
     category = '',
     channelIds = [],
-    limit = 20,
+    limit = 5,
     skip = 0,
   } = {}) {
     const { ContentItem } = this.context.dataSources;

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -5,6 +5,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     PRIORITY_CONTENT_FEED: this.priorityContentFeedAlgorithm.bind(this),
+    DAILY_SCRIPTURE_FEED: this.dailyScriptureFeedAlgorithm.bind(this),
     WEEKLY_SCRIPTURE_FEED: this.weeklyScriptureFeedAlgorithm.bind(this),
   };
 
@@ -65,6 +66,34 @@ class dataSource extends ActionAlgorithm.dataSource {
     }));
   }
 
+  async dailyScriptureFeedAlgorithm({
+    category = '',
+    channelIds = [],
+    limit = 20,
+    skip = 0,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    const items = (await Promise.all(
+      channelIds.map(async (channel) =>
+        (await ContentItem.byContentChannelId(channel, category))
+          .top(limit)
+          .skip(skip)
+          .get()
+      )
+    )).flat();
+
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: item.contentChannel?.name,
+      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
+      image: ContentItem.getCoverImage(item),
+      action: 'READ_CONTENT',
+      summary: ContentItem.createSummary(item),
+    }));
+  }
+
   async weeklyScriptureFeedAlgorithm({
     category = '',
     channelIds = [],
@@ -85,7 +114,7 @@ class dataSource extends ActionAlgorithm.dataSource {
     )).flat();
 
     const itemsByDate = items.filter((key) =>
-      isThisWeek(new Date(key.startDateTime))
+      isThisWeek(new Date(key.startDateTime), 1)
     );
 
     return itemsByDate.map((item, i) => ({

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -5,7 +5,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     PRIORITY_CONTENT_FEED: this.priorityContentFeedAlgorithm.bind(this),
-    DAILY_SCRIPTURE_FEED: this.dailyScriptureFeedAlgorithm.bind(this),
+    WEEKLY_SCRIPTURE_FEED: this.weeklyScriptureFeedAlgorithm.bind(this),
   };
 
   async contentFeedAlgorithm({
@@ -65,7 +65,7 @@ class dataSource extends ActionAlgorithm.dataSource {
     }));
   }
 
-  async dailyScriptureFeedAlgorithm({
+  async weeklyScriptureFeedAlgorithm({
     category = '',
     channelIds = [],
     limit = 5,

--- a/apollos-church-api/src/data/ActionAlgorithms.js
+++ b/apollos-church-api/src/data/ActionAlgorithms.js
@@ -4,6 +4,7 @@ class dataSource extends ActionAlgorithm.dataSource {
   ACTION_ALGORITHMS = {
     ...this.ACTION_ALGORITHMS,
     PRIORITY_CONTENT_FEED: this.priorityContentFeedAlgorithm.bind(this),
+    DAILY_SCRIPTURE_FEED: this.dailyScriptureFeedAlgorithm.bind(this),
   };
 
   async contentFeedAlgorithm({
@@ -48,6 +49,36 @@ class dataSource extends ActionAlgorithm.dataSource {
           .top(limit)
           .skip(skip)
           .sort([{ field: 'Priority', direction: 'asc' }])
+          .get()
+      )
+    )).flat();
+
+    return items.map((item, i) => ({
+      id: `${item.id}${i}`,
+      title: item.title,
+      subtitle: item.contentChannel?.name,
+      relatedNode: { ...item, __type: ContentItem.resolveType(item) },
+      image: ContentItem.getCoverImage(item),
+      action: 'READ_CONTENT',
+      summary: ContentItem.createSummary(item),
+    }));
+  }
+
+  async dailyScriptureFeedAlgorithm({
+    category = '',
+    channelIds = [],
+    limit = 20,
+    skip = 0,
+  } = {}) {
+    const { ContentItem } = this.context.dataSources;
+
+    const items = (await Promise.all(
+      channelIds.map(async (channel) =>
+        (await ContentItem.byContentChannelId(channel, category))
+          // First, get all the items for this week (even if not live yet)
+          .top(limit)
+          .skip(skip)
+          // Then, sort chronologically ascending
           .get()
       )
     )).flat();

--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -72,11 +72,12 @@ class dataSource extends ContentItem.dataSource {
     return sermonAttributeValues.map((attr) => attr.entityId);
   };
 
-  baseChannelById = this.byContentChannelId;
-
   byContentChannelId = async (id, category = '', filtered = true) => {
-    if (!filtered) return this.baseChannelById(id);
-
+    if (!filtered)
+      return this.request()
+        .filter(`ContentChannelId eq ${id}`)
+        .cache({ ttl: 60 })
+        .orderBy('StartDateTime', 'desc');
     const { Auth, Campus } = this.context.dataSources;
 
     const person = await Auth.getCurrentPerson();


### PR DESCRIPTION
This PR builds out two channels:

### 📖 Daily Scripture
This is a typical Content Feed channel that will display the latest item in the channel. There is nothing custom about this channel.

### 📚 Weekly Scripture
This is an Action List channel that will display the 5 Weekly Scripture items for this week (M, T, W, R, F) and will display these items until midnight on Sunday. I made a custom algorithm for pulling, and sorting the data. I also restructured the filtering to allow items that are not live (their startDateTime in Rock is later than today), but do occur this week, to still show up in the app. It also properly sorts the items, to display them from Monday to Friday. Finally, I adjusted the subtitle on items to be a formatted version of startDateTime from Rock.

### 📷 Screenshots/Videos

![simulator_screenshot_A2F27C37-96BD-40C5-B5CC-462A2D3B768C](https://user-images.githubusercontent.com/72768221/135687546-c02bfbf5-c0da-4a2c-b641-712f1d9beeeb.png)

This video demonstrates the difference of `items` and `itemsByDate` and the sorting logic of this PR.
https://user-images.githubusercontent.com/72768221/135687612-6fe1a17a-cc94-4f0b-94f5-cb0668a8140a.mov


