### PR TITLE
chore: added a new channel to the Home Tab

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -204,6 +204,13 @@ TABS:
           arguments:
             limit: 1
             channelIds:
+              - 41
+      type: VerticalCardList
+    - algorithms:
+        - type: CONTENT_FEED
+          arguments:
+            limit: 1
+            channelIds:
               - 37
       type: VerticalCardList
     - subtitle: Featured


### PR DESCRIPTION
This will display just below the Weekly Reading list and just above the Fight for Godliness, Digital Book content channel.