### PR TITLE
fix: changed the link on Recent Series > View All to go to website

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -301,12 +301,11 @@ TABS:
               - 12
       type: HorizontalCardList
       primaryAction:
-        action: OPEN_CHANNEL
+        action: OPEN_URL
         title: 'View all'
         relatedNode:
-          __typename: ContentChannel
-          id: 12
-          name: Recent Series
+          __typename: Url
+          url: 'https://fellowshipnwa.org/services'
 
     - subtitle: Podcasts # Missing Content Channel in Rock
       algorithms:


### PR DESCRIPTION
This PR changes a View All link to go to their website instead of opening the channel in the app.

https://user-images.githubusercontent.com/72768221/138321817-4a294a19-de98-4181-88cc-f00f8ceaea80.mp4


