### PR TITLE
chore: changed overlay to paper

### DIFF
--- a/apolloschurchapp/src/ui/CurrentCampus.js
+++ b/apolloschurchapp/src/ui/CurrentCampus.js
@@ -34,7 +34,7 @@ const stretchyStyle = {
 };
 
 const Image = withTheme(({ theme }) => ({
-  overlayColor: theme.colors.primary,
+  overlayColor: theme.colors.paper,
   overlayType: 'gradient-bottom',
   style: stretchyStyle,
 }))(GradientOverlayImage);


### PR DESCRIPTION
The overlay was too light in dark mode, making the text hard to read. This change makes the overlay slightly darker in light mode as well as making dark mode easier to read.

Before:
<img src="https://user-images.githubusercontent.com/72768221/138737621-d5a2293d-c3f0-4288-8df3-6d3658d528d1.png" width='50%'>

After:
<img src="https://user-images.githubusercontent.com/72768221/138737631-5c2e369d-e001-4907-96ef-d13d302055fe.png" width='50%'>