### PR TITLE
chore: bumped versions for working deploys

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -156,7 +156,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 141
-        versionName "1.0.2"
+        versionName "1.0.3"
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>22</string>
 	<key>NSExtension</key>

--- a/apolloschurchapp/ios/fellowshipNWA/Info.plist
+++ b/apolloschurchapp/ios/fellowshipNWA/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fellowshipNWA",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
I believe that this will fix our broken deploys. Bumped all versions from 1.0.2 to 1.0.3.