### PR TITLE
chore: Fix android builds

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -156,7 +156,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 141
-        versionName "1.0.3"
+        versionName "1.0.4"
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.2"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 30
+        targetSdkVersion = 30
         ndkVersion = "18.1.5063045"
     }
     repositories {

--- a/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>22</string>
 	<key>NSExtension</key>

--- a/apolloschurchapp/ios/fellowshipNWA/Info.plist
+++ b/apolloschurchapp/ios/fellowshipNWA/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fellowshipNWA",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
This PR bumps the versions to 1.0.4 and also targets version 30 of sdk. This was an issue as evidenced in the two errors below.

<img width="740" alt="Screen Shot 2021-11-08 at 2 45 51 PM" src="https://user-images.githubusercontent.com/72768221/140815537-8a40abb1-78e3-4e42-ae83-3b9e15886fe3.png">
