### PR TITLE
chore: update fastlane info for church name

### DIFF
--- a/apolloschurchapp/android/app/src/main/res/values/strings.xml
+++ b/apolloschurchapp/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Fellowship NWA</string>
+    <string name="app_name">Fellowship Bible Church NWA</string>
 </resources>

--- a/apolloschurchapp/app.json
+++ b/apolloschurchapp/app.json
@@ -1,4 +1,4 @@
 {
   "name": "fellowshipNWA",
-  "displayName": "Fellowship NWA"
+  "displayName": "Fellowship Bible Church NWA"
 }

--- a/apolloschurchapp/fastlane/metadata/android/en-US/full_description.txt
+++ b/apolloschurchapp/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
-Welcome to the official Fellowship NWA app!
+Welcome to the official Fellowship Bible Church NWA app!
 
 We hope this app provides you all with easy access to all of our resources. We have sermons, event information, daily devotionals and so much more. Feel free to recommend this app to any of your friends who are looking for a church to connect with.
 
-For more information about Fellowship NWA please visit: http://www.fellowshipnwa.org/welcome-students-sunday
+For more information about Fellowship Bible Church NWA please visit: http://www.fellowshipnwa.org/welcome-students-sunday
 
-The Fellowship NWA App was created with the Apollos Project.
+The Fellowship Bible Church NWA App was created with the Apollos Project.

--- a/apolloschurchapp/fastlane/metadata/android/en-US/title.txt
+++ b/apolloschurchapp/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Fellowship NWA
+Fellowship Bible Church NWA


### PR DESCRIPTION
This PR adjusts the name displayed in to Fellowship Bible Church NWA instead of Fellowship NWA, so that this is updated for all future fastlane deploys.