### PR TITLE
feat: added support for calendar link url on events

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -298,10 +298,13 @@ class dataSource extends ContentItem.dataSource {
     }
 
     // sign up button
-    const signupURL = `${process.env.ROCK_URL}${
-      item.attributeValues.registrationLinkUrl?.value
-    }`;
+    let signupURL = '';
+
     if (item.attributeValues.registrationLinkUrl?.value) {
+      signupURL = `${process.env.ROCK_URL}${
+        item.attributeValues.registrationLinkUrl?.value
+      }`;
+
       features.push(
         Feature.createButtonFeature({
           id: item.attributeValues.registrationLinkUrl.id,
@@ -311,7 +314,25 @@ class dataSource extends ContentItem.dataSource {
               url: signupURL,
             },
             action: 'OPEN_AUTHENTICATED_URL',
-            title: 'Sign Up',
+            title: 'Register',
+          }),
+        })
+      );
+    } else if (item.attributeValues.calendarLinkUrl?.value) {
+      signupURL = `${process.env.ROCK_URL}${
+        item.attributeValues.calendarLinkUrl?.value
+      }`;
+
+      features.push(
+        Feature.createButtonFeature({
+          id: item.attributeValues.calendarLinkUrl.id,
+          action: Feature.attachActionIds({
+            relatedNode: {
+              __typename: 'Url',
+              url: signupURL,
+            },
+            action: 'OPEN_AUTHENTICATED_URL',
+            title: 'Learn More',
           }),
         })
       );


### PR DESCRIPTION
This PR adds additional logic to our Events content items, allowing the button to be programmatically created based on whether or not there is a registrationLinkUrl value, or a calendarLinkUrl. Tested extensively to confirm it works as intended.

How to test this PR
1. Go to [this content item](https://rock.fellowshipnwa.org/page/342?ContentItemId=2741)
2. Delete the Registration Link Url, and replace the Calendar Link Url with /event/624
3. Reload that content item in the app
4. The button text should change and the link will take you to a different content item
5. **Reset the content item before you leave to /event/623 on both fields**